### PR TITLE
Apply all market data review improvements (#4–7)

### DIFF
--- a/backend/app/market/__init__.py
+++ b/backend/app/market/__init__.py
@@ -12,6 +12,7 @@ from .cache import PriceCache
 from .factory import create_market_data_source
 from .interface import MarketDataSource
 from .models import PriceUpdate
+from .prices import create_prices_router
 from .stream import create_stream_router
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "PriceCache",
     "MarketDataSource",
     "create_market_data_source",
+    "create_prices_router",
     "create_stream_router",
 ]

--- a/backend/app/market/cache.py
+++ b/backend/app/market/cache.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import time
+from collections import deque
 from threading import Lock
 
 from .models import PriceUpdate
+
+# Maximum number of historical price points kept per ticker
+HISTORY_MAX_LEN = 200
 
 
 class PriceCache:
@@ -13,10 +17,16 @@ class PriceCache:
 
     Writers: SimulatorDataSource or MassiveDataSource (one at a time).
     Readers: SSE streaming endpoint, portfolio valuation, trade execution.
+
+    In addition to the current price, a rolling history of the last
+    HISTORY_MAX_LEN (200) PriceUpdate objects is kept per ticker so that
+    REST clients can bootstrap charts and sparklines without waiting for the
+    SSE stream to accumulate data.
     """
 
     def __init__(self) -> None:
         self._prices: dict[str, PriceUpdate] = {}
+        self._history: dict[str, deque[PriceUpdate]] = {}
         self._lock = Lock()
         self._version: int = 0  # Monotonically increasing; bumped on every update
 
@@ -25,6 +35,7 @@ class PriceCache:
 
         Automatically computes direction and change from the previous price.
         If this is the first update for the ticker, previous_price == price (direction='flat').
+        The update is appended to the rolling history buffer for the ticker.
         """
         with self._lock:
             ts = timestamp or time.time()
@@ -38,6 +49,11 @@ class PriceCache:
                 timestamp=ts,
             )
             self._prices[ticker] = update
+
+            if ticker not in self._history:
+                self._history[ticker] = deque(maxlen=HISTORY_MAX_LEN)
+            self._history[ticker].append(update)
+
             self._version += 1
             return update
 
@@ -56,15 +72,27 @@ class PriceCache:
         update = self.get(ticker)
         return update.price if update else None
 
+    def get_history(self, ticker: str) -> list[PriceUpdate]:
+        """Return the rolling price history for a ticker (up to 200 points).
+
+        Returns an empty list if the ticker is unknown or has no history.
+        The list is ordered oldest-first.
+        """
+        with self._lock:
+            hist = self._history.get(ticker)
+            return list(hist) if hist else []
+
     def remove(self, ticker: str) -> None:
-        """Remove a ticker from the cache (e.g., when removed from watchlist)."""
+        """Remove a ticker from the cache and its history (e.g., watchlist removal)."""
         with self._lock:
             self._prices.pop(ticker, None)
+            self._history.pop(ticker, None)
 
     @property
     def version(self) -> int:
         """Current version counter. Useful for SSE change detection."""
-        return self._version
+        with self._lock:
+            return self._version
 
     def __len__(self) -> int:
         with self._lock:

--- a/backend/app/market/massive_client.py
+++ b/backend/app/market/massive_client.py
@@ -39,6 +39,9 @@ class MassiveDataSource(MarketDataSource):
         self._client: RESTClient | None = None
 
     async def start(self, tickers: list[str]) -> None:
+        if self._task is not None:
+            logger.warning("Massive poller already started; ignoring duplicate start() call")
+            return
         self._client = RESTClient(api_key=self._api_key)
         self._tickers = list(tickers)
 

--- a/backend/app/market/prices.py
+++ b/backend/app/market/prices.py
@@ -1,0 +1,50 @@
+"""REST endpoints for price data (history)."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from .cache import PriceCache
+
+logger = logging.getLogger(__name__)
+
+
+def create_prices_router(price_cache: PriceCache) -> APIRouter:
+    """Create the prices REST router with a reference to the price cache.
+
+    Endpoints:
+        GET /api/prices/{ticker}/history  — last 200 price points for a ticker
+    """
+    router = APIRouter(prefix="/api/prices", tags=["prices"])
+
+    @router.get("/{ticker}/history")
+    async def get_price_history(ticker: str) -> list[dict]:
+        """Return the rolling price history for a ticker (up to 200 points).
+
+        Bootstraps frontend sparklines and the main chart on page load so
+        clients don't have to wait for the SSE stream to accumulate data.
+
+        Returns 404 if the ticker is not in the cache (not on the watchlist
+        or not yet seeded).
+
+        Response: JSON array ordered oldest-first, each element matching the
+        PriceUpdate.to_dict() shape:
+            [{"ticker": "AAPL", "price": 190.50, "previous_price": 190.00,
+              "timestamp": 1234567890.0, "change": 0.5,
+              "change_percent": 0.2632, "direction": "up"}, ...]
+        """
+        normalized = ticker.upper().strip()
+        history = price_cache.get_history(normalized)
+
+        if not history:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No price history available for {normalized}. "
+                "Ticker may not be on the watchlist or data has not yet been seeded.",
+            )
+
+        return [update.to_dict() for update in history]
+
+    return router

--- a/backend/app/market/simulator.py
+++ b/backend/app/market/simulator.py
@@ -217,6 +217,9 @@ class SimulatorDataSource(MarketDataSource):
         self._task: asyncio.Task | None = None
 
     async def start(self, tickers: list[str]) -> None:
+        if self._task is not None:
+            logger.warning("Simulator already started; ignoring duplicate start() call")
+            return
         self._sim = GBMSimulator(
             tickers=tickers,
             event_probability=self._event_prob,

--- a/backend/tests/market/test_cache.py
+++ b/backend/tests/market/test_cache.py
@@ -101,3 +101,73 @@ class TestPriceCache:
         cache = PriceCache()
         update = cache.update("AAPL", 190.12345)
         assert update.price == 190.12
+
+    # --- History tests ---
+
+    def test_get_history_single_update(self):
+        """Test that a single update appears in history."""
+        cache = PriceCache()
+        update = cache.update("AAPL", 190.00)
+        history = cache.get_history("AAPL")
+        assert len(history) == 1
+        assert history[0] == update
+
+    def test_get_history_multiple_updates_ordered(self):
+        """Test that history is ordered oldest-first."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("AAPL", 191.00)
+        cache.update("AAPL", 192.00)
+        history = cache.get_history("AAPL")
+        assert len(history) == 3
+        assert history[0].price == 190.00
+        assert history[1].price == 191.00
+        assert history[2].price == 192.00
+
+    def test_get_history_unknown_ticker(self):
+        """Test that get_history returns empty list for unknown ticker."""
+        cache = PriceCache()
+        assert cache.get_history("NOPE") == []
+
+    def test_get_history_capped_at_200(self):
+        """Test that history is capped at 200 entries."""
+        cache = PriceCache()
+        for i in range(250):
+            cache.update("AAPL", float(100 + i))
+        history = cache.get_history("AAPL")
+        assert len(history) == 200
+        # Oldest retained entry should be price 150 (250 - 200 + 100 = 150)
+        assert history[0].price == 150.0
+
+    def test_remove_clears_history(self):
+        """Test that removing a ticker also clears its history."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("AAPL", 191.00)
+        cache.remove("AAPL")
+        assert cache.get_history("AAPL") == []
+
+    def test_history_independent_per_ticker(self):
+        """Test that history is tracked independently per ticker."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("AAPL", 191.00)
+        cache.update("GOOGL", 175.00)
+        assert len(cache.get_history("AAPL")) == 2
+        assert len(cache.get_history("GOOGL")) == 1
+
+    def test_get_history_returns_copy(self):
+        """Test that get_history returns a list copy (not the internal deque)."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        history = cache.get_history("AAPL")
+        history.clear()  # Mutating the returned list should not affect the cache
+        assert len(cache.get_history("AAPL")) == 1
+
+    def test_version_read_is_consistent(self):
+        """Test that version reads are consistent under concurrent writes."""
+        cache = PriceCache()
+        # Sanity check: version is 0 before any writes
+        assert cache.version == 0
+        cache.update("AAPL", 190.00)
+        assert cache.version == 1

--- a/backend/tests/market/test_massive.py
+++ b/backend/tests/market/test_massive.py
@@ -199,3 +199,18 @@ class TestMassiveDataSource:
         assert cache.get_price("AAPL") == 190.50
 
         await source.stop()
+
+    async def test_start_is_idempotent(self):
+        """Test that calling start() twice does not leak a background task."""
+        cache = PriceCache()
+        source = MassiveDataSource(api_key="test-key", price_cache=cache, poll_interval=60.0)
+
+        with patch("app.market.massive_client.RESTClient"):
+            with patch.object(source, "_fetch_snapshots", return_value=[]):
+                await source.start(["AAPL"])
+                first_task = source._task
+                # Second call should be a no-op — task object must not change
+                await source.start(["GOOGL"])
+                assert source._task is first_task
+
+        await source.stop()

--- a/backend/tests/market/test_prices.py
+++ b/backend/tests/market/test_prices.py
@@ -1,0 +1,123 @@
+"""Tests for the /api/prices/{ticker}/history REST endpoint."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.market.cache import PriceCache
+from app.market.prices import create_prices_router
+
+
+def _make_app(cache: PriceCache) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_prices_router(cache))
+    return app
+
+
+class TestCreatePricesRouter:
+    """Tests for create_prices_router factory."""
+
+    def test_returns_router_with_correct_prefix(self):
+        """Test that the router is created with /api/prices prefix."""
+        from fastapi import APIRouter
+
+        cache = PriceCache()
+        router = create_prices_router(cache)
+        assert isinstance(router, APIRouter)
+        assert router.prefix == "/api/prices"
+
+    def test_router_has_history_route(self):
+        """Test that the router registers the history route."""
+        cache = PriceCache()
+        router = create_prices_router(cache)
+        paths = [route.path for route in router.routes]
+        assert "/api/prices/{ticker}/history" in paths
+
+    def test_each_call_returns_fresh_router(self):
+        """Test factory isolation: two calls produce independent routers."""
+        cache = PriceCache()
+        r1 = create_prices_router(cache)
+        r2 = create_prices_router(cache)
+        assert r1 is not r2
+        assert len(r1.routes) == len(r2.routes) == 1
+
+
+class TestPriceHistoryEndpoint:
+    """Integration tests for GET /api/prices/{ticker}/history."""
+
+    def test_returns_404_for_unknown_ticker(self):
+        cache = PriceCache()
+        client = TestClient(_make_app(cache))
+        response = client.get("/api/prices/ZZZZ/history")
+        assert response.status_code == 404
+
+    def test_returns_history_for_known_ticker(self):
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("AAPL", 191.00)
+        client = TestClient(_make_app(cache))
+
+        response = client.get("/api/prices/AAPL/history")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["price"] == 190.00
+        assert data[1]["price"] == 191.00
+
+    def test_response_shape_contains_all_fields(self):
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        cache.update("AAPL", 191.00)
+        client = TestClient(_make_app(cache))
+
+        response = client.get("/api/prices/AAPL/history")
+        point = response.json()[1]  # second update has non-flat direction
+        assert "ticker" in point
+        assert "price" in point
+        assert "previous_price" in point
+        assert "timestamp" in point
+        assert "change" in point
+        assert "change_percent" in point
+        assert "direction" in point
+
+    def test_ticker_normalised_to_uppercase(self):
+        """Lowercase ticker in URL should still match cache entry."""
+        cache = PriceCache()
+        cache.update("AAPL", 190.00)
+        client = TestClient(_make_app(cache))
+
+        response = client.get("/api/prices/aapl/history")
+        assert response.status_code == 200
+
+    def test_returns_at_most_200_points(self):
+        """History is capped at 200 entries by the cache."""
+        cache = PriceCache()
+        for i in range(250):
+            cache.update("MSFT", float(400 + i))
+        client = TestClient(_make_app(cache))
+
+        response = client.get("/api/prices/MSFT/history")
+        assert response.status_code == 200
+        assert len(response.json()) == 200
+
+    def test_history_ordered_oldest_first(self):
+        """History list must be ordered oldest-first."""
+        cache = PriceCache()
+        prices = [100.0, 105.0, 110.0, 95.0]
+        for p in prices:
+            cache.update("TSLA", p)
+        client = TestClient(_make_app(cache))
+
+        data = client.get("/api/prices/TSLA/history").json()
+        assert [d["price"] for d in data] == prices
+
+    def test_returns_404_for_removed_ticker(self):
+        """After removal the history is gone too."""
+        cache = PriceCache()
+        cache.update("NVDA", 800.00)
+        cache.remove("NVDA")
+        client = TestClient(_make_app(cache))
+
+        response = client.get("/api/prices/NVDA/history")
+        assert response.status_code == 404

--- a/backend/tests/market/test_simulator.py
+++ b/backend/tests/market/test_simulator.py
@@ -45,7 +45,7 @@ class TestGBMSimulator:
         """Test that adding a duplicate ticker is a no-op."""
         sim = GBMSimulator(tickers=["AAPL"])
         sim.add_ticker("AAPL")
-        assert len(sim._tickers) == 1
+        assert len(sim.get_tickers()) == 1
 
     def test_remove_nonexistent_is_noop(self):
         """Test that removing a non-existent ticker is a no-op."""

--- a/backend/tests/market/test_simulator_source.py
+++ b/backend/tests/market/test_simulator_source.py
@@ -136,3 +136,16 @@ class TestSimulatorDataSource:
         # Just verify it starts and stops cleanly
         await asyncio.sleep(0.2)
         await source.stop()
+
+    async def test_start_is_idempotent(self):
+        """Test that calling start() twice does not leak a background task."""
+        cache = PriceCache()
+        source = SimulatorDataSource(price_cache=cache, update_interval=0.1)
+        await source.start(["AAPL"])
+        first_task = source._task
+
+        # Second call should be a no-op — the task object must not change
+        await source.start(["GOOGL"])
+        assert source._task is first_task
+
+        await source.stop()


### PR DESCRIPTION
## Summary

Implements every remaining improvement from `MARKET_DATA_REVEW.md` (items #4–7). Items #1–3 were fixed and merged in PR #9.

### Changes

**#4 — Lock `version` read in `PriceCache` (`cache.py`)**
All writes to `_version` were already locked; the `version` property now also acquires the lock on read. Eliminates a theoretical data race under GIL-free Python (PEP 703 / 3.13+).

**#5 — Guard `start()` against double-call (`simulator.py`, `massive_client.py`)**
Both `SimulatorDataSource.start()` and `MassiveDataSource.start()` now return early (logging a warning) if already running. Prevents background task leaks if called more than once, honouring the contract documented in `MarketDataSource`.

**#6 — Use public API in tests (`test_simulator.py`)**
`test_add_duplicate_is_noop` now uses `sim.get_tickers()` instead of the private `sim._tickers` attribute.

**#7 — Price history buffer and `GET /api/prices/{ticker}/history` endpoint (spec gap)**
- `PriceCache` now maintains a rolling `deque(maxlen=200)` of `PriceUpdate` objects per ticker. New `get_history(ticker) -> list[PriceUpdate]` method returns the buffer oldest-first. `remove()` also clears history.
- New `prices.py` module with `create_prices_router(cache)` factory. Registers `GET /api/prices/{ticker}/history`: returns 404 for unknown tickers, normalises ticker to uppercase, responds with the `PriceUpdate.to_dict()` shape array.
- `__init__.py` exports `create_prices_router` alongside the existing symbols.

### Tests

| File | New tests |
|------|-----------|
| `test_cache.py` | +8 (history: single update, ordering, 200-cap, remove clears, per-ticker independence, copy safety, version lock) |
| `test_simulator_source.py` | +1 (idempotent `start()`) |
| `test_massive.py` | +1 (idempotent `start()`) |
| `test_prices.py` | +10 (router factory, HTTP endpoint: 404, shape, case-normalisation, 200-cap, ordering, post-remove 404) |

**106 tests, all passing. Lint clean (`ruff`). Coverage 97%.**

## Test plan
- [x] `pytest tests/market/ -q` → `106 passed`
- [x] `ruff check app/market/ tests/market/` → `All checks passed!`
- [x] Coverage report shows all new code at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)